### PR TITLE
Added support for redis 5.0.0

### DIFF
--- a/src/Smoke/Cache/Storage/Adapter/RedisArray.php
+++ b/src/Smoke/Cache/Storage/Adapter/RedisArray.php
@@ -290,7 +290,7 @@ class RedisArray extends AbstractAdapter implements
     {
         $redis = $this->getRedisResource();
         try {
-            return (bool) $redis->delete($this->namespacePrefix . $normalizedKey);
+            return (bool) $redis->del($this->namespacePrefix . $normalizedKey);
         } catch (RedisResourceException $e) {
             throw new Exception\RuntimeException($redis->getLastError(), $e->getCode(), $e);
         }


### PR DESCRIPTION
As of Redis 5.0.0, the extension will trigger a deprecation error if using `Redis::delete`, `RedisArray::delete` and `RedisCluster::delete`.